### PR TITLE
要求するmikutterのバージョンを3.5.0-developに変更

### DIFF
--- a/.mikutter.yml
+++ b/.mikutter.yml
@@ -1,7 +1,7 @@
 ---
 slug: :mikutter_slack
 depends:
-  mikutter: 3.3.9
+  mikutter: 3.5.0-develop
   plugin: []
 version: '0.0.1'
 author: ahiru


### PR DESCRIPTION
.mikutter.ymlに、3.3系を要求するように書いてあったが、3.5の機能を使っているので、より正しい表記に変えた。
これで、mikutterを過去のバージョンに戻して起動しても、slackプラグインはロードされないので、クラッシュしなくなる。
