### PR TITLE
Activityを使って通知する

### DIFF
--- a/.mikutter.yml
+++ b/.mikutter.yml
@@ -2,7 +2,8 @@
 slug: :mikutter_slack
 depends:
   mikutter: 3.3.9
-  plugin: []
+  plugin:
+    - activity
 version: '0.0.1'
 author: ahiru
 name: mikutter_slack

--- a/mikutter_slack.rb
+++ b/mikutter_slack.rb
@@ -118,6 +118,7 @@ Plugin.create(:mikutter_slack) do
     RTM.start
   end
 
+  defactivity 'slack_connection', 'Slack接続情報'
 
   # 実績
   # http://mikutter.blogspot.jp/2013/03/blog-post.html
@@ -143,11 +144,11 @@ Plugin.create(:mikutter_slack) do
     end end
 
   on_slack_connected do |auth|
-    timeline(:home_timeline) << Mikutter::System::Message.new(description: "Slackチーム #{auth['team']} の認証に成功しました！\n")
+    activity :slack_connection, "Slackチーム #{auth['team']} の認証に成功しました！"
   end
 
   on_slack_connection_failed do |auth|
-    timeline(:home_timeline) << Mikutter::System::Message.new(description: "Slackチーム #{auth['team']} の認証に失敗しました！\n")
+    activity :slack_connection, "Slackチーム #{auth['team']} の認証に失敗しました！"
   end
 
 end

--- a/mikutter_slack.rb
+++ b/mikutter_slack.rb
@@ -28,8 +28,11 @@ Plugin.create(:mikutter_slack) do
   # 認証テスト
   def auth_test
     auth = Slack.auth_test
-    result = auth['ok'] ? '成功' : '失敗'
-    timeline(:home_timeline) << Mikutter::System::Message.new(description: "Slackチーム #{auth['team']} の認証に#{result}しました！\n")
+    if auth['ok']
+      Plugin.call(:slack_connected, auth)
+    else
+      Plugin.call(:slack_connection_failed, auth)
+    end
   end
 
 
@@ -138,5 +141,13 @@ Plugin.create(:mikutter_slack) do
     settings('開発') do
       input('トークン', :mikutter_slack_token)
     end end
+
+  on_slack_connected do |auth|
+    timeline(:home_timeline) << Mikutter::System::Message.new(description: "Slackチーム #{auth['team']} の認証に成功しました！\n")
+  end
+
+  on_slack_connection_failed do |auth|
+    timeline(:home_timeline) << Mikutter::System::Message.new(description: "Slackチーム #{auth['team']} の認証に失敗しました！\n")
+  end
 
 end


### PR DESCRIPTION
Slackで話していた #6 の話です。
# イベントを使う

これは本筋ではないけれど、重要なテクニックなので。知ってたらすまん。

auth_test メソッドは、接続が完了した後に、 **slackに正しく接続できたか確認し、成否をSystem Messageを使って通知する** 機能をもっている。
今回は、 `slack_connected`（と、`slack_connection_failed`）イベントを新たに新設して、auth_testは　**slackに正しく接続できたか確認し、成否によって別々のイベントを発生させる** メソッドにした。
また、新たにそれぞれのイベントのリスナを定義し、 **成否をSystem Messageを使って通知する** ようにした。

一見冗長になるけれど、イベントは単なるメソッドの呼び出しと違って、イベントリスナを幾つでも定義できるので、接続成功時に他にもやりたいことが増えた場合、呼び出し元のauth_testメソッドを変更しなくてもよくなる。機能追加のコストが安くなるばかりか、まったく他人が書いたプラグインがこのプラグインと連携したい時に、mikutter_slack側を変更しなくて良い。

実はこれがマージされたら「接続ができた時にslackの実績を解除する」というpull-reqを送ろうと思ってる（今は、設定値に何かがあれば解除となっている）。その変更を見れば、上に書いたことのわかりみが深くなると思う。
# アクティビティ

アクティビティについては以下のページにマニュアルがある。
https://toshia.github.io/writing-mikutter-plugin/example/2016/09/04/activity-example.html
お前がこの間リンク切れ指摘してたページざゃオッラーン！！！

いかなる方法を使おうとも、System Messageをサードパーティプラグインが作成するのはobsoleteです。Activityを使っておくれ。

![20160927020810](https://cloud.githubusercontent.com/assets/586906/18844233/74db8dae-8457-11e6-941c-bb0e5c2f5787.png)

ただし、標準ではActivityタブにしか通知は表示されないので、ホームタイムライン上ではわからない。このあたりは知っての通り、ユーザがどの種類の通知をどこに表示するかを設定すべきなので、プラグインから具体的にどこにどう表示すべきかを指定する方法は<s>（公式には）</s>存在しない。ユーザに委ねよう。
尤もこんなふうに書けば、一般エラーメッセージになるので目立つように通知されるようになる。これに関しても、デフォルトがそうなっているという話で、設定を変更することはできるので、保証はない。

``` ruby
    activity :error, "あひる焼き"
```
