### PR TITLE
クラス名とスコープ

### DIFF
--- a/mikutter_slack.rb
+++ b/mikutter_slack.rb
@@ -29,14 +29,14 @@ Plugin.create(:mikutter_slack) do
   RTM.on :hello do
     puts 'Successfully connected.'
 
-    SlackAPI.auth_test
+    Plugin::Slack::SlackAPI.auth_test
     # channel_history(EVENTS, channels(EVENTS), 'mikutter')
   end
 
 
   # メッセージ書き込み時に呼ばれる
   RTM.on :message do |data|
-    users = SlackAPI.users(EVENTS)
+    users = Plugin::Slack::SlackAPI.users(EVENTS)
 
     # TODO: モデルでこの部分を調整する
     # user = Mikutter::Slack::User.new(idname: "#{users[data['user']]}",
@@ -44,7 +44,7 @@ Plugin.create(:mikutter_slack) do
     #                                  profile_image_url: get_icon(EVENTS, data['user']))
     user = Mikutter::System::User.new(idname: "#{users[data['user']]}",
                                       name: "#{users[data['user']]}",
-                                      profile_image_url: SlackAPI.get_icon(EVENTS, data['user']))
+                                      profile_image_url: Plugin::Slack::SlackAPI.get_icon(EVENTS, data['user']))
     timeline(:home_timeline) << Mikutter::System::Message.new(user: user,
                                                               description: "#{data['text']}")
   end

--- a/mikutter_slack.rb
+++ b/mikutter_slack.rb
@@ -29,14 +29,14 @@ Plugin.create(:mikutter_slack) do
   RTM.on :hello do
     puts 'Successfully connected.'
 
-    Slack_API.auth_test
+    SlackAPI.auth_test
     # channel_history(EVENTS, channels(EVENTS), 'mikutter')
   end
 
 
   # メッセージ書き込み時に呼ばれる
   RTM.on :message do |data|
-    users = Slack_API.users(EVENTS)
+    users = SlackAPI.users(EVENTS)
 
     # TODO: モデルでこの部分を調整する
     # user = Mikutter::Slack::User.new(idname: "#{users[data['user']]}",
@@ -44,7 +44,7 @@ Plugin.create(:mikutter_slack) do
     #                                  profile_image_url: get_icon(EVENTS, data['user']))
     user = Mikutter::System::User.new(idname: "#{users[data['user']]}",
                                       name: "#{users[data['user']]}",
-                                      profile_image_url: Slack_API.get_icon(EVENTS, data['user']))
+                                      profile_image_url: SlackAPI.get_icon(EVENTS, data['user']))
     timeline(:home_timeline) << Mikutter::System::Message.new(user: user,
                                                               description: "#{data['text']}")
   end

--- a/slack_api.rb
+++ b/slack_api.rb
@@ -1,77 +1,79 @@
 # -*- coding: utf-8 -*-
 require 'slack'
 
-class SlackAPI
-  class << self
-    # 認証テスト
-    # @return [boolean] 認証成功の可否
-    def auth_test
-      auth = Slack.auth_test
-      if auth['ok']
-        Plugin.call(:slack_connected, auth)
-      else
-        Plugin.call(:slack_connection_failed, auth)
-      end
-      auth['ok'] end
+module Plugin::Slack
+  class SlackAPI
+    class << self
+      # 認証テスト
+      # @return [boolean] 認証成功の可否
+      def auth_test
+        auth = Slack.auth_test
+        if auth['ok']
+          Plugin.call(:slack_connected, auth)
+        else
+          Plugin.call(:slack_connection_failed, auth)
+        end
+        auth['ok'] end
 
 
-    # ユーザーリストを取得
-    # @param [Slack::Client] events EVENTS APIのインスタンス
-    # @return [Array] ユーザーリスト
-    def users(events)
-      Hash[events.users_list['members'].map { |m| [m['id'], m['name']] }] end
+      # ユーザーリストを取得
+      # @param [Slack::Client] events EVENTS APIのインスタンス
+      # @return [Array] ユーザーリスト
+      def users(events)
+        Hash[events.users_list['members'].map { |m| [m['id'], m['name']] }] end
 
 
-    # チャンネルリスト返す
-    # @param [Slack::Client] events EVENTS APIのインスタンス(EVENTS)
-    # @return [Array] channels チャンネル一覧
-    def channels(events)
-      events.channels_list['channels'] end
+      # チャンネルリスト返す
+      # @param [Slack::Client] events EVENTS APIのインスタンス(EVENTS)
+      # @return [Array] channels チャンネル一覧
+      def channels(events)
+        events.channels_list['channels'] end
 
 
-    # 全てのチャンネルのヒストリを取得
-    # FIXME: messageオブジェクトを返したほうがいい？
-    def all_channel_history
-      channel = channels(EVENTS)
-      users = users(EVENTS)
-      messages = client.channels_history(channel: "#{channel['id']}")['messages']
-      messages.each do |message|
-        username = users[message['user']]
-        print "@#{username} "
-        puts message['text']
-      end end
-
-
-    # 指定したチャンネル名のチャンネルのヒストリを取得
-    # FIXME: messageオブジェクトを返したほうがいい？
-    def channel_history(events ,channel, name)
-      if channel['name'] == name
-        users = users(events)
-        messages = events.channels_history(channel: "#{channel['id']}")['messages']
+      # 全てのチャンネルのヒストリを取得
+      # FIXME: messageオブジェクトを返したほうがいい？
+      def all_channel_history
+        channel = channels(EVENTS)
+        users = users(EVENTS)
+        messages = client.channels_history(channel: "#{channel['id']}")['messages']
         messages.each do |message|
           username = users[message['user']]
           print "@#{username} "
           puts message['text']
-        end
-      end end
+        end end
 
 
-    # Emojiリストの取得
-    # @param [Slack::Client] events EVENTS APIのインスタンス
-    # @return Array 絵文字リスト
-    def emoji_list(events)
-      events.emoji_list end
+      # 指定したチャンネル名のチャンネルのヒストリを取得
+      # FIXME: messageオブジェクトを返したほうがいい？
+      def channel_history(events ,channel, name)
+        if channel['name'] == name
+          users = users(events)
+          messages = events.channels_history(channel: "#{channel['id']}")['messages']
+          messages.each do |message|
+            username = users[message['user']]
+            print "@#{username} "
+            puts message['text']
+          end
+        end end
 
 
-    # ユーザのアイコンを取得
-    # @param [Slack::Client] events APIのインスタンス
-    # @param [String] id ユーザーID
-    # @return FIXME: 確認する（どういう形か忘れた）
-    def get_icon(events, id)
-      events.users_list['members'].each { |u|
-        return u.dig('profile', 'image_48') if u['id'] == id
-      }
-      Skin.get('icon.png') end
+      # Emojiリストの取得
+      # @param [Slack::Client] events EVENTS APIのインスタンス
+      # @return Array 絵文字リスト
+      def emoji_list(events)
+        events.emoji_list end
 
+
+      # ユーザのアイコンを取得
+      # @param [Slack::Client] events APIのインスタンス
+      # @param [String] id ユーザーID
+      # @return FIXME: 確認する（どういう形か忘れた）
+      def get_icon(events, id)
+        events.users_list['members'].each { |u|
+          return u.dig('profile', 'image_48') if u['id'] == id
+        }
+        Skin.get('icon.png') end
+
+    end
   end
 end

--- a/slack_api.rb
+++ b/slack_api.rb
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 require 'slack'
 
-class Slack_API
+class SlackAPI
   class << self
     # 認証テスト
     # @return [boolean] 認証成功の可否


### PR DESCRIPTION
# Rubyのクラス名

Rubyでよく採用されているコーディング規約では、先頭が大文字のキャメルケースを用い、クラス名に_が使用されていることはないので、取り除いた。

ただし、APIのような略語は、全て大文字で表記するとあるので（標準ライブラリにもNet::HTTPというのがある）、Apiとせず、単に_を取った。

参考: https://shugo.net/ruby-codeconv/codeconv.html の、「クラス・モジュール名」という節
# mikutterプラグインの名前空間

名前空間という言葉はあんまり適切じゃないと思うけど、Rubyではmoduleを名前空間的に使う。
上で直したSlackAPIは、トップレベルに定義されてしまっているが、mikutterプラグインは `Plugin::<Plugin slug>` というmoduleの中であれば、他のプラグインとの名前の衝突を気にせずに好きなように定数（クラス）を定義できることになっている。

現に、このリポジトリのretriever.rbではこのテクニックが既に使われているので、SlackAPIにも同じように変更を行った
