### PR TITLE
初めて接続が完了した段階で、実績mikutter_slack_achieveを解除

### DIFF
--- a/mikutter_slack.rb
+++ b/mikutter_slack.rb
@@ -63,9 +63,10 @@ Plugin.create(:mikutter_slack) do
                  description: '設定画面からSlackのトークンを設定しよう',
                  hint: "Slackのトークンを取得して設定しよう！\nhttps://api.slack.com/docs/oauth-test-tokens"
   ) do |achievement|
-    token = UserConfig['mikutter_slack_token']
-    unless token.empty? || token.nil?
-      achievement.take! end end
+    on_slack_connected do |auth|
+      achievement.take!
+    end
+  end
 
 
   # mikutter設定画面


### PR DESCRIPTION
#8 の時に追加した `slack_connected` イベントを使って、接続された瞬間に実績が解除されるようにした。

タイミングも完璧になったし、間違ったトークンが入っていても実績が解除されてしまう問題も解決したし、この部分も読みやすくなったと思うので爆アド完全優勝
