### PR TITLE
ChannelのデータソースにMessageが配信されていない

### DIFF
--- a/api.rb
+++ b/api.rb
@@ -58,7 +58,9 @@ module Plugin::Slack
     def channel_history(channels, name)
       Thread.new do
         channel = channels.find { |c| c['name'] == name }
-        @client.channels_history(channel: "#{channel['id']}")['messages']
+        @client.channels_history(channel: "#{channel['id']}")['messages'].map{|message_hash|
+          message_hash.merge('channel' => channel['id'])
+        }
       end
     end
 

--- a/slack.rb
+++ b/slack.rb
@@ -20,7 +20,7 @@ Plugin.create(:slack) do
     slack_api.channels.next { |channels|
       list = Hash.new
       channels.each do |channel|
-        list["slack_#{'team'}_#{channel['name']}"] = ['slack', 'team', "#{channel['name']}"]
+        list["slack_#{'team'}_#{channel['id']}"] = ['slack', 'team', "#{channel['name']}"]
       end
       list
     }


### PR DESCRIPTION
データソース :slack に対してMessageを配信するようになっているが、現在設定画面ではチームごとのデータソースが提供されていて、 :slack というデータソースはない。

古いslackプラグインでデータソース :slack を使うように設定しておかないと、現在slackの投稿を受信できない状態になっていたので、設定画面から設定できるデータソースにちゃんとMessageを配信するようにした。

このprを取り込んだら、正しいデータソースに配信されるようになるため、抽出タブの設定をやり直さないといけません。
