### PR TITLE
Team model

### DIFF
--- a/api.rb
+++ b/api.rb
@@ -93,7 +93,7 @@ module Plugin::Slack
     private
 
     memoize def team!
-      Plugin::Slack::Team.new(@client.team_info['team'].symbolize)
+      Plugin::Slack::Team.new(@client.team_info['team'].symbolize.merge(api: self))
     end
   end
 end

--- a/api/realtime.rb
+++ b/api/realtime.rb
@@ -42,7 +42,7 @@ module Plugin::Slack
           team.channels.next { |channels|
             channels.each do |channel|
               slack_api.channel_history(channel).next { |messages|
-                Plugin.call :extract_receive_message, :"slack_#{channel.team.id}_#{channel.id}", messages
+                Plugin.call :extract_receive_message, channel.datasource_slug, messages
               }.trap { |err|
                 error err
               }
@@ -81,7 +81,7 @@ module Plugin::Slack
                                                text: data['text'],
                                                created: Time.at(Float(data['ts']).to_i),
                                                team: 'test')
-          Plugin.call(:extract_receive_message, :"slack_#{message.team.id}_#{message.channel.id}", [message])
+          Plugin.call(:extract_receive_message, channel.datasource_slug, [message])
         }
       }.trap { |err|
         error err

--- a/api/realtime.rb
+++ b/api/realtime.rb
@@ -38,16 +38,16 @@ module Plugin::Slack
         # Activityに通知
         Plugin.call(:slack_connected, auth)
 
-        # チャンネル一覧取得
-        slack_api.channels.next { |channels|
-          # チャンネルヒストリ取得
-          channels.each do |channel|
-            slack_api.channel_history(channel).next { |messages|
-              Plugin.call :extract_receive_message, :"slack_#{channel.team.id}_#{channel.id}", messages
-            }.trap { |err|
-              error err
-            }
-          end
+        slack_api.team.next { |team|
+          team.channels.next { |channels|
+            channels.each do |channel|
+              slack_api.channel_history(channel).next { |messages|
+                Plugin.call :extract_receive_message, :"slack_#{channel.team.id}_#{channel.id}", messages
+              }.trap { |err|
+                error err
+              }
+            end
+          }
         }.trap { |err|
           error err
         }
@@ -71,13 +71,18 @@ module Plugin::Slack
       # FIXME: Entityを使ってメッセージの整形をする
 
       # メッセージの処理
-      Delayer::Deferred.when(slack_api.users_dict, slack_api.channels_dict).next { |users, channels|
-        message = Plugin::Slack::Message.new(channel: channels[data['channel']],
-                                             user: users[data['user']],
-                                             text: data['text'],
-                                             created: Time.at(Float(data['ts']).to_i),
-                                             team: 'test')
-        Plugin.call(:extract_receive_message, :"slack_#{message.team.id}_#{message.channel.id}", [message])
+      slack_api.team.next{ |team|
+        Delayer::Deferred.when(
+          team.user(data['user']),
+          team.channel(data['channel'])
+        ).next { |user, channel|
+          message = Plugin::Slack::Message.new(channel: channel,
+                                               user: user,
+                                               text: data['text'],
+                                               created: Time.at(Float(data['ts']).to_i),
+                                               team: 'test')
+          Plugin.call(:extract_receive_message, :"slack_#{message.team.id}_#{message.channel.id}", [message])
+        }
       }.trap { |err|
         error err
       }

--- a/model/channel.rb
+++ b/model/channel.rb
@@ -13,5 +13,13 @@ module Plugin::Slack
     field.has :team, Plugin::Slack::Team, required: true
     field.int :unread_count
     field.int :unread_count_display
+
+    def datasource_slug
+      :"slack_#{team.id}_#{id}"
+    end
+
+    def datasource_name
+      ['slack', team.name, name]
+    end
   end
 end

--- a/model/team.rb
+++ b/model/team.rb
@@ -9,5 +9,55 @@ module Plugin::Slack
     field.string :name, required: true
     field.string :domain, required: true
     field.string :email_domain
+
+    # このチームに所属しているユーザを列挙する
+    # @return [Delayer::Deferred::Deferredable] チームの全ユーザを引数にcallbackするDeferred
+    def users
+      cache = @users
+      if cache
+        Delayer::Deferred.new.next{ cache }
+      else
+        api.users.next{ |u| @users = u.freeze }
+      end
+    end
+
+    # ユーザIDに対応するUserをcallbackするDeferredを返す。
+    # IDに対応するユーザが見つからなかった場合は、nilを引数に、trapブロックが呼ばれる。
+    # @param [String] ユーザID
+    # @return [Delayer::Deferred::Deferredable] Userを引数にcallbackするDeferred
+    def user(user_id)
+      id_detector(users, user_id)
+    end
+
+    # このチームの全てのChannelを列挙する
+    # @return [Delayer::Deferred::Deferredable] チームの全Channelを引数にcallbackするDeferred
+    def channels
+      cache = @channels
+      if cache
+        Delayer::Deferred.new.next{ cache }
+      else
+        api.channels.next{ |c| @channels = c.freeze }
+      end
+    end
+
+    # チャンネルIDに対応するChannelをcallbackするDeferredを返す。
+    # IDに対応するチャンネルが見つからなかった場合は、nilを引数に、trapブロックが呼ばれる。
+    # @param [String] channel_id チャンネルID
+    # @return [Delayer::Deferred::Deferredable] Channelを引数にcallbackするDeferred
+    def channel(channel_id)
+      id_detector(channels, channel_id)
+    end
+
+    private
+
+    def id_detector(defer, id)
+      defer.next{ |list|
+        list.find{ |o| o.id == id } or Delayer::Deferred.fail(:id_notfound)
+      }
+    end
+
+    def api
+      self[:api]
+    end
   end
 end

--- a/model/team.rb
+++ b/model/team.rb
@@ -21,6 +21,16 @@ module Plugin::Slack
       end
     end
 
+    # このチームに所属しているユーザを、メモリキャッシュから返す。
+    # もしこのTeamのインスタンスにユーザがキャッシュされていない場合は、nilを返す。
+    # Deferredで結果を遅らせることができず、すぐに結果が手に入らないなら失敗したほうが良い場合にこのメソッドを使う。
+    # APIリクエストをしても良い場合はこのメソッドの代わりに Plugin::Slack::Team#users を利用する。
+    # @return [Array] チームに所属するユーザの配列
+    # @return [nil] 取得に失敗した場合
+    def users!
+      @users
+    end
+
     # ユーザIDに対応するUserをcallbackするDeferredを返す。
     # IDに対応するユーザが見つからなかった場合は、nilを引数に、trapブロックが呼ばれる。
     # @param [String] ユーザID
@@ -38,6 +48,16 @@ module Plugin::Slack
       else
         api.channels.next{ |c| @channels = c.freeze }
       end
+    end
+
+    # このチームに所属しているチャンネルを、メモリキャッシュから返す。
+    # もしこのTeamのインスタンスにチャンネルがキャッシュされていない場合は、nilを返す。
+    # Deferredで結果を遅らせることができず、すぐに結果が手に入らないなら失敗したほうが良い場合にこのメソッドを使う。
+    # APIリクエストをしても良い場合はこのメソッドの代わりに Plugin::Slack::Team#channels を利用する。
+    # @return [Array] チームに所属するチャンネルの配列
+    # @return [nil] 取得に失敗した場合
+    def channels!
+      @channels
     end
 
     # チャンネルIDに対応するChannelをcallbackするDeferredを返す。


### PR DESCRIPTION
TeamとChannelができたので、ただの入れ物じゃなくて関係するModelをAPIから取得できるようにした。

Team#channels でChannelのインスタンスをAPIから取得して配列でDeferredに渡す。
Team#users でUsers〃

あと、Team#user(id) とか Team#channel(id) とか、よく使うIDからインスタンスをとってくるやつも作った。APIクラスを使わずにTeamを使うことには今の所以下のメリットがあることになる
- 記述量が少ない
- 内部でうまいことModelをメモリキャッシュしているので、APIリクエストを抑えることができる

Channel等がメモリキャッシュされるようになったので、抽出タブデータソースを事前に作成する必要がなくなった。今後は `extract_datasources` フィルタが呼び出されたら、キャッシュからChannelリストを取ってきて、キャッシュになかったらslack関連のデータソースを返さないという挙動になった。
具体的には、mikutterを起動してRTMへの接続が完了する前に抽出タブの設定を開いてしまうと（回線がめっちゃ遅い、ユーザが兄貴等の場合に発生しうる）、slack関連のデータソースが表示されない。しかし今までもチャンネルをとってきた後にフィルタを定義していたから同じような現象が発生していたはず。要するに仕組みは変わったがこれによるデメリットは特にないと思う。

最後にこれはちょっと関係ないけれど、Channel Modelができたおかげで、データソースのslugを作成するちょうどよい場所ができた。ソースコードの中で3箇所も同じSymbolを生成している場所があって、今後も増えるような雰囲気があったので、Channel#datasource_slug などを新たに定義した。
