### PR TITLE
Messageのパーマリンク

### DIFF
--- a/api.rb
+++ b/api.rb
@@ -77,7 +77,8 @@ module Plugin::Slack
                                        user: users[history['user']],
                                        text: history['text'],
                                        created: Time.at(Float(history['ts']).to_i),
-                                       team: channel[:team].name)
+                                       team: channel[:team].name,
+                                       ts: history['ts'])
           end
         }
       end

--- a/api.rb
+++ b/api.rb
@@ -29,7 +29,11 @@ module Plugin::Slack
       # ユーザーリストを取得
       # @return [Delayer::Deferred::Deferredable] チームの全ユーザを引数にcallbackするDeferred
       def users
-        Thread.new { @client.users_list['members'].map { |m| Plugin::Slack::User.new(m.symbolize) } }
+        Delayer::Deferred.when(Thread.new { @client.users_list['members'] }, team).next do |user_list, a_team|
+          user_list.map do |m|
+            Plugin::Slack::User.new(m.symbolize.merge(team: a_team))
+          end
+        end
       end
 
       # ユーザーリストを取得する。

--- a/api/channel.rb
+++ b/api/channel.rb
@@ -52,7 +52,8 @@ module Plugin::Slack
                                        user: users[history['user']],
                                        text: history['text'],
                                        created: Time.at(Float(history['ts']).to_i),
-                                       team: channel[:team].name)
+                                       team: channel[:team].name,
+                                       ts: history['ts'])
           }
         }
       end
@@ -96,7 +97,8 @@ module Plugin::Slack
                                        user: users[history['user']],
                                        text: history['text'],
                                        created: Time.at(Float(history['ts']).to_i),
-                                       team: channel[:team].name)
+                                       team: channel[:team].name,
+                                       ts: history['ts'])
           end
         }
       end

--- a/api/realtime.rb
+++ b/api/realtime.rb
@@ -72,7 +72,8 @@ module Plugin::Slack
                                                user: user,
                                                text: data['text'],
                                                created: Time.at(Float(data['ts']).to_i),
-                                               team: team[:name])
+                                               team: team[:name],
+                                               ts: data['ts'])
           Plugin.call(:extract_receive_message, channel.datasource_slug, [message])
         }
       }.trap { |err|

--- a/model/channel.rb
+++ b/model/channel.rb
@@ -22,6 +22,10 @@ module Plugin::Slack
       ['slack', team.name, name]
     end
 
+    def perma_link
+      Retriever::URI("https://#{team.domain}.slack.com/archives/#{name}/")
+    end
+
     def inspect
       "#{self.class.to_s}(id=#{id}, name=#{name})"
     end

--- a/model/message.rb
+++ b/model/message.rb
@@ -19,6 +19,7 @@ module Plugin::Slack
     field.string :text, required: true
     field.time   :created
     field.string :team, required: true
+    field.string :ts, required: true
 
     entity_class Retriever::Entity::URLEntity
     entity_class Plugin::Slack::Entity::MessageEntity

--- a/model/message.rb
+++ b/model/message.rb
@@ -34,6 +34,10 @@ module Plugin::Slack
       channel.team
     end
 
+    def perma_link
+      Retriever::URI("https://#{team.domain}.slack.com/archives/#{channel.name}/p#{ts.gsub('.','')}")
+    end
+
     def inspect
       "#{self.class.to_s}(channel=#{channel.to_s}, user=#{user.to_s})"
     end

--- a/model/team.rb
+++ b/model/team.rb
@@ -89,6 +89,10 @@ module Plugin::Slack
       id_detector(emojis, emoji_name)
     end
 
+    def perma_link
+      Retriever::URI("https://#{domain}.slack.com/")
+    end
+
     private
 
     def id_detector(defer, id)

--- a/model/user.rb
+++ b/model/user.rb
@@ -9,6 +9,7 @@ module Plugin::Slack
 
     field.string :id, required: true
     field.string :name, required: true
+    field.has :team, Plugin::Slack::Team, required: true
 
     def idname
       name
@@ -16,6 +17,10 @@ module Plugin::Slack
 
     def profile_image_url
       self[:profile][:image_48]
+    end
+
+    def perma_link
+      Retriever::URI("https://#{team.domain}.slack.com/team/#{name}")
     end
 
     def inspect


### PR DESCRIPTION
Message, Channel, Teamにperma_linkメソッドを定義した。

パーマリンクがあると、

- 同じチャンネルを指している別々のChannelのインスタンスが同じものとして取り扱われる
  - タイムラインの重複登録制御にも影響するので、 #44 が解消される
- Intentに対応させる時に便利

なのでぜひとも設定しておいたほうが良い。
他、Messageに限ってはパーマリンクがあることによって、「ブラウザで開く」「パーマリンクをコピー」などのmikutterコマンドが使えるようになった。
