### PR TITLE
存在しない変数を参照している

### DIFF
--- a/entity/message_entity.rb
+++ b/entity/message_entity.rb
@@ -48,7 +48,7 @@ module Plugin::Slack
         #   @hoge -> <user_id> または <user_id|hoge>
         filter(/<(@(U[\w\-]+)).*?>/, generator: -> s {
           matched = /<(@(?<id>U.+?)(?:\|(?<name>.+))?)>/.match(s[:face])
-          name = matched[:name] || "loading(#{id})"
+          name = matched[:name] || "loading(#{matched[:id]})"
 
           if matched[:name].nil?
             s[:message].team.user(matched[:id]).next { |user|


### PR DESCRIPTION
```
 undefined local variable or method `id' for Plugin::Slack::Entity:Module
         from mikutter/core/lib/retriever/entity/regexp_entity.rb:46:in `block (3 levels) in filter'
```

というバックトレースを出力してクラッシュしてしまっていた

#54 ミスっていた