### PR TITLE
Message Modelはto_showのオーバーライドをやめ、descriptionは本文を正しく返す #58

### DIFF
--- a/model/message.rb
+++ b/model/message.rb
@@ -22,9 +22,7 @@ module Plugin::Slack
     entity_class Retriever::Entity::URLEntity
     entity_class Plugin::Slack::Entity::MessageEntity
 
-    def to_show
-      self[:text]
-    end
+    alias_method :description, :text
 
     # このMessageが所属するTeam
     # @return [Plugin::Slack::Team] チーム


### PR DESCRIPTION
Plugin::Slack::Entity::MessageEntity#to_show を、Plugin::Slack::Message#to_show がオーバーライドしてしまっていて、オーバーライドしたコードがアンエスケープを行っていなかった。

Plugin::Slack::Entity::MessageEntity#to_show は、descriptionメソッドが「エスケープされた本文」を返すことを期待した実装になっているので、textフィールドの内容を返すdescriptionメソッドをPlugin::Slack::Messageに実装