### PR TITLE
投稿部分をcompose spellを使って書き直した

### DIFF
--- a/.mikutter.yml
+++ b/.mikutter.yml
@@ -2,7 +2,9 @@
 slug: :slack
 depends:
   mikutter: 3.6.0-develop
-  plugin: []
+  plugin:
+    - world
+    - spell
 version: 0.2.0
 author: ahiru
 name: slack

--- a/model/channel.rb
+++ b/model/channel.rb
@@ -75,8 +75,10 @@ module Plugin::Slack
     # メッセージの投稿
     #
     # @param [String] text 投稿メッセージ
+    # @deprecated Use compose spell instead.
     def post(text)
-      team.api.channel.post(self, text)
+      world, = Plugin.filtering(:world_current, nil) unless world
+      Plugin[:slack].compose(self, world, body: text)
     end
 
     # チャンネルのリンクを返す

--- a/model/message.rb
+++ b/model/message.rb
@@ -41,17 +41,16 @@ module Plugin::Slack
       Diva::URI("https://#{team.domain}.slack.com/archives/#{channel.name}/p#{ts.delete('.')}")
     end
 
+    # @deprecated Use compose spell instead.
     def postable?(world=nil)
       world, = Plugin.filtering(:world_current, nil) unless world
-      world.class.slug == :slack and world.team == team
+      Plugin[:slack].compose?(self, world)
     end
 
+    # @deprecated Use compose spell instead.
     def post(to: nil, message:, **kwrest)
-      responder = Array(to).first
-      responder, = Plugin.filtering(:world_current, nil) unless responder
-      if responder.is_a?(Diva::Model) and responder.class.slug == :slack
-        responder.post(to: [channel], message: message, **kwrest)
-      end
+      world, = Plugin.filtering(:world_current, nil)
+      Plugin[:slack].compose(self, world, body: message)
     end
 
     def inspect

--- a/model/world.rb
+++ b/model/world.rb
@@ -62,27 +62,14 @@ module Plugin::Slack
                   })
     end
 
+    # @deprecated Use compose spell instead.
     def post(to: nil, message:, **kwrest)
-      responders = Array(to)
-      case
-      when responders.size == 1 && responders.first.class.slug == :slack_channel
-        Thread.new{
-          api.client.chat_postMessage(channel: responders.first.id, text: message, as_user: true)
-        }
-      when responders.size == 1 && responders.first.class.slug == :slack_message
-        Thread.new{
-          api.client.chat_postMessage(channel: responders.first.channel.id, text: message, as_user: true)
-        }
-      end if responders.first.is_a?(Diva::Model)
+      Plugin[:slack].compose(self, to, body: message)
     end
 
+    # @deprecated Use compose spell instead.
     def postable?(target=nil)
-      case target
-      when Plugin::Slack::Channel
-        target.team == team
-      when Plugin::Slack::Message
-        target.team == team
-      end
+      Plugin[:slack].compose?(self, target)
     end
 
     def inspect

--- a/slack.rb
+++ b/slack.rb
@@ -19,6 +19,25 @@ Plugin.create(:slack) do
   # slack api インスタンス作成
   start_realtime
 
+  defspell(:compose, :slack, :slack_channel,
+           condition: ->(slack, channel){
+             slack.team == channel.team
+           }) do |slack, channel, body:|
+    Thread.new{
+      slack.api.client.chat_postMessage(channel: channel.id, text: body, as_user: true)
+    }
+  end
+
+  defspell(:compose, :slack, :slack_message,
+           condition: ->(slack, message){
+             slack.team == message.team
+           }) do |slack, message, body:|
+    Thread.new{
+      slack.api.client.chat_postMessage(channel: message.channel.id, text: body, as_user: true)
+    }
+  end
+
+
   # 抽出データソース
   # @see https://toshia.github.io/writing-mikutter-plugin/basis/2016/09/20/extract-datasource.html
   filter_extract_datasources do |ds|


### PR DESCRIPTION
<!-- 必要な項目だけ埋めてくだしあ -->
<!-- これを使った http://blog.hotolab.net/entry/github_template -->

# 概要
<!-- 変更の目的 もしくは 関連する Issue 番号 -->
mikutterのspellブランチで追加されたspellプラグインで提供されるspell機能を使って投稿処理を書き換えました。

# 変更内容
<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
今のところslackプラグインで実装されている機能のうちspellで実装すべきなのは投稿処理のみなので、それを実装し直しました。

# 影響範囲
<!-- この関数を変更したのでこの機能にも影響がある、など -->
各Modelのpostやpostable?がcomposeというspellに置き換わっています。
もともとのメソッドはcompose spellを呼ぶようになっているので、もともと動いていたプラグインには影響はありません。

mikutterのspellブランチは、postboxやバンドルプラグインが全てcompose spellを利用するように書き換えているので、slackでこれを実装しない場合、投稿できない状態になります。

# 動作要件
<!-- 動作に必要な 環境変数 / 依存関係 / DBの更新 など -->
mikutter の spell ブランチ。もうすぐworldにmergeするので、READMEの更新はいらないかと

# 補足
<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
今の所Spellを実装するに当たってこれが最小で最もわかりやすいサンプルっぽい